### PR TITLE
Corrección de errores menores

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -808,6 +808,76 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &323333727
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.89999986
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.89999986
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.10002041
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.74310046
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6691799
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230838, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_Name
+      value: pared prueba (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+--- !u!4 &323333728 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+  m_PrefabInstance: {fileID: 323333727}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &328283499
 GameObject:
   m_ObjectHideFlags: 0
@@ -1838,63 +1908,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 2140532941445721662, guid: fe4f1ec9a80303f49a07b27c5541a716, type: 3}
   m_PrefabInstance: {fileID: 760844460}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &777015825
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -13.60272
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.35007
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -31.556309
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.74310046
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.6691799
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 84.008
-      objectReference: {fileID: 0}
-    - target: {fileID: 2092943985742784713, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6505218325808694531, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
-      propertyPath: m_Name
-      value: module_1D_1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c48e04d76670a1a42be8b59466a1b022, type: 3}
 --- !u!224 &836571032 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2950329543875201241, guid: de9f76029c1b1a04eaa16c77aefd2bf4, type: 3}
@@ -1994,6 +2007,76 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &915870031
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.89999986
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.89999986
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.0729566
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.10002041
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.180114
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.74310046
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6691799
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230838, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_Name
+      value: pared prueba
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+--- !u!4 &915870032 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+  m_PrefabInstance: {fileID: 915870031}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &921965915 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4639919941622023525, guid: 0720f62793c00c84c90e4b3ceea43ae2, type: 3}
@@ -2699,6 +2782,76 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1152220345}
   m_CullTransparentMesh: 1
+--- !u!1001 &1307989170
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.89999986
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.89999986
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.10002041
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.04387107
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.99903727
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -174.971
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9831506321230838, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+      propertyPath: m_Name
+      value: pared prueba (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+--- !u!4 &1307989171 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9831506321230729, guid: 06fd3ebcd9dc7224c97b27589329d131, type: 3}
+  m_PrefabInstance: {fileID: 1307989170}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1359293800
 GameObject:
   m_ObjectHideFlags: 0
@@ -4464,6 +4617,361 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2107145490}
   m_CullTransparentMesh: 1
+--- !u!1001 &1017914520013556000
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 1518265617077956317, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_Name
+      value: Container (ral-1005)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.90039
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.20032
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.005464779
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9999851
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180180.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+--- !u!4 &1017914520013556001 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+  m_PrefabInstance: {fileID: 1017914520013556000}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1132276155343321963
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 603194600505019773, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_Name
+      value: Papers (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.70027
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000009536743
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.20022
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.08308744
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9965423
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -189.532
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+--- !u!4 &1132276155343321964 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+  m_PrefabInstance: {fileID: 1132276155343321963}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1474728452463352266
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.50015
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00000047683716
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.90039
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5943189913811301960, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+      propertyPath: m_Name
+      value: Container (ral-3000)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+--- !u!4 &1474728452463352267 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4304810139986218223, guid: a30acdb7b2c742e45acbb914989ea29e, type: 3}
+  m_PrefabInstance: {fileID: 1474728452463352266}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2040317117421298553
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.8041897
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00000047683716
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.20032
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700683536498798879, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_Name
+      value: Container (ral-6010) 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+--- !u!4 &2040317117421298554 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+  m_PrefabInstance: {fileID: 2040317117421298553}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2092943986375097048
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6505218325241403154}
+  m_LocalRotation: {x: -0, y: 0.6691799, z: -0, w: 0.74310046}
+  m_LocalPosition: {x: -13.60272, y: 0.35007, z: -31.556309}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6659360514218442876}
+  - {fileID: 1017914520013556001}
+  - {fileID: 1474728452463352267}
+  - {fileID: 7349852013751787299}
+  - {fileID: 2040317117421298554}
+  - {fileID: 2153722296082642922}
+  - {fileID: 6806423883838551655}
+  - {fileID: 3983642356550741925}
+  - {fileID: 5854723797323312314}
+  - {fileID: 6868168185868652446}
+  - {fileID: 4803937662621156966}
+  - {fileID: 1132276155343321964}
+  - {fileID: 7075675744147887360}
+  - {fileID: 4786898401271279003}
+  - {fileID: 3125991049644947283}
+  - {fileID: 915870032}
+  - {fileID: 323333728}
+  - {fileID: 1307989171}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 84.008, z: 0}
+--- !u!1001 &2153722296082642921
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 1819031590745360082, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_Name
+      value: Tire
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000023841858
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.825
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+--- !u!4 &2153722296082642922 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+  m_PrefabInstance: {fileID: 2153722296082642921}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2950329543066945345
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4577,6 +5085,142 @@ PrefabInstance:
       objectReference: {fileID: 1051419031}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de9f76029c1b1a04eaa16c77aefd2bf4, type: 3}
+--- !u!1001 &3125991049644947282
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 7126293510535426713, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_Name
+      value: Barrel (red) (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.384
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+--- !u!4 &3125991049644947283 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+  m_PrefabInstance: {fileID: 3125991049644947282}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3983642356550741924
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 1819031590745360082, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_Name
+      value: Tire (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.804
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.102
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+--- !u!4 &3983642356550741925 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+  m_PrefabInstance: {fileID: 3983642356550741924}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4238174694493202583
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4863,6 +5507,480 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0720f62793c00c84c90e4b3ceea43ae2, type: 3}
+--- !u!1001 &4786898401271279002
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 7126293510535426713, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_Name
+      value: Barrel (red)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+--- !u!4 &4786898401271279003 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7615163230391035939, guid: 272ee7a446f2fe3408f88776466de2b8, type: 3}
+  m_PrefabInstance: {fileID: 4786898401271279002}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4803937662621156965
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 603194600505019773, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_Name
+      value: Papers
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.50025
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000014305115
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0001
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9267078
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.37578273
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 44.145
+      objectReference: {fileID: 0}
+    - target: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+--- !u!4 &4803937662621156966 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6261018980798094163, guid: 936341c59c75a9c4cb4ed4a08c39c71a, type: 3}
+  m_PrefabInstance: {fileID: 4803937662621156965}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5854723797323312313
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 1819031590745360082, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_Name
+      value: Tire (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+--- !u!4 &5854723797323312314 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+  m_PrefabInstance: {fileID: 5854723797323312313}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6505218325241403154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2092943986375097048}
+  m_Layer: 0
+  m_Name: module_1D_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1001 &6659360514218442875
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8989698754309768049, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+      propertyPath: m_Name
+      value: Light
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+--- !u!4 &6659360514218442876 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5085155612851876227, guid: bb600c16d6d1cca43820e65fe96c5166, type: 3}
+  m_PrefabInstance: {fileID: 6659360514218442875}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6806423883838551654
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 1819031590745360082, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_Name
+      value: Tire (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.266
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+--- !u!4 &6806423883838551655 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3225139247530877259, guid: fa39789b797e52c47944a6e24deaaf66, type: 3}
+  m_PrefabInstance: {fileID: 6806423883838551654}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6868168185868652445
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.20032
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00000047683716
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.90039
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700683536498798879, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+      propertyPath: m_Name
+      value: Container (ral-6010) 1 (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+--- !u!4 &6868168185868652446 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 343276765914940490, guid: 9925292664397ed4db6207637c3c9df5, type: 3}
+  m_PrefabInstance: {fileID: 6868168185868652445}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7075675744147887359
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 7126293510535426713, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_Name
+      value: Barrel (blue)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.037
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.422
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+--- !u!4 &7075675744147887360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7615163230391035939, guid: 69ad510c1f9360b49a568b4d10218c7f, type: 3}
+  m_PrefabInstance: {fileID: 7075675744147887359}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7347503040593690268
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5080,3 +6198,65 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 54a824d5653c6d246bfcc4206af5e219, type: 3}
+--- !u!1001 &7349852013751787298
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2092943986375097048}
+    m_Modifications:
+    - target: {fileID: 1518265617077956317, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_Name
+      value: Container (ral-1005) (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.0002
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00000047683716
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.90039
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+--- !u!4 &7349852013751787299 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6445305038589727597, guid: 982ef026d3560404dbe164cfe520d2e1, type: 3}
+  m_PrefabInstance: {fileID: 7349852013751787298}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Sripts/ActiveObjects/AmmoBox.cs
+++ b/Assets/Sripts/ActiveObjects/AmmoBox.cs
@@ -19,8 +19,7 @@ public class AmmoBox : MonoBehaviour
 
                     if (shootScript.availableGuns[i])
                     {
-
-                        sg.totalBullets = sg.maxTotalBullets - sg.magazineSize;
+                        sg.totalBullets += sg.magazineSize*3;
 
                     }
                 }

--- a/Assets/Sripts/Perks/Gunsmith.cs
+++ b/Assets/Sripts/Perks/Gunsmith.cs
@@ -33,13 +33,7 @@ public class Gunsmith : MonoBehaviour
 
             if (shootScript.availableGuns[i])
             {
-
                 sg.totalBullets += ammoRegenAmount;
-
-                if(sg.totalBullets + sg.magazineSize > sg.maxTotalBullets)
-                {
-                    sg.totalBullets = sg.maxTotalBullets - sg.magazineSize;
-                }
             }
         }
     }

--- a/Assets/Sripts/Perks/PerksManager.cs
+++ b/Assets/Sripts/Perks/PerksManager.cs
@@ -106,7 +106,6 @@ public class PerksManager : MonoBehaviour
         InitializeMedicFactors();
         InitializeElectricBarrierFactors();
         InitializeGunsmithFactors();
-        ActivateElectricalBarrier();
     }
 
     ////////////////////////Initialize perks factors////////////////////////

--- a/Assets/Sripts/Player/ShootSystem.cs
+++ b/Assets/Sripts/Player/ShootSystem.cs
@@ -219,6 +219,7 @@ public class ShootSystem : MonoBehaviour
         Debug.Log("Intenta recargar");
         if ((guns.getGuns()[selectedGun].bulletsLeftInMagazine < guns.getGuns()[selectedGun].magazineSize) && !reloading && guns.getGuns()[selectedGun].totalBullets > 0)
         {
+            shooting = false;
             Debug.Log("Pasa");
             audioManager.PlaySecundary(selectedGun);
             reloading = true;


### PR DESCRIPTION
Se cambian los muros en el menú principal.
La caja de munición no recargar hasta las balas máximas iniciales si no que da una cantidad arbitraria. Lo mismo para la ventaja Gunsmith. Se desactiva la inicialización de una ventaja del demonio. Se arregla un error del manejo de arma que permitia recargar a la vez que se dispara.