### PR TITLE
InvincibilityTime

### DIFF
--- a/Assets/Sripts/Modes/NoGunsMode.cs
+++ b/Assets/Sripts/Modes/NoGunsMode.cs
@@ -9,6 +9,7 @@ public class NoGunsMode : MonoBehaviour
     void Start()
     {
         player = GameObject.FindGameObjectWithTag("Player");
+        player.GetComponent<Health>().SetInvincibilityTime(0.5f);
         ShootSystem sS = player.GetComponentInChildren<ShootSystem>();
 
         for (int i = 0; i < sS.guns.getGuns().Length; i++)

--- a/Assets/Sripts/Player/Health.cs
+++ b/Assets/Sripts/Player/Health.cs
@@ -190,4 +190,8 @@ public class Health : MonoBehaviour
         canBeHurt = true;
         lifeScaler.GetComponent<Image>().color = lifeColorNormal;
     }
+
+    public void SetInvincibilityTime(float time) {
+        invincibilityTime = time;
+    }
 }


### PR DESCRIPTION
Al cambiar la forma en la que spawnea el jugador en el modo NoGuns, la invencibilidad ya no se aplicaba. Se arregla mediante scripting.