### PR TITLE
Error de UI de tienda

### DIFF
--- a/Assets/Sripts/Shop/ManageShops.cs
+++ b/Assets/Sripts/Shop/ManageShops.cs
@@ -431,8 +431,8 @@ public class ManageShops : MonoBehaviour
                     idxExistentPerks[numPerksGenerated] = idx;
                     generatedExistenPerks[idx] = true;
                     perksNewOldGeneratedIndexes[numPerksGenerated + 1] = idx;
+                    numPerksGenerated++;
                 }
-                numPerksGenerated++;
             }
             
             


### PR DESCRIPTION
Se arregla un error que hacia que la UI mostrase una ventaja equivocada en el caso de tener 4 ventajas compradas.